### PR TITLE
Use write_all to avoid partial writes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -270,7 +270,7 @@ fn parse_content(
 }
 
 fn process_response(cli: &Cli, lbin: &mut LineBufferedStdin) -> Result<(), Box<dyn Error>> {
-    std::io::stdout().write(b"{")?;
+    std::io::stdout().write_all(b"{")?;
 
     skip(lbin)?;
     parse_status_line(lbin)?;
@@ -290,7 +290,7 @@ fn process_response(cli: &Cli, lbin: &mut LineBufferedStdin) -> Result<(), Box<d
     }
     skip(lbin)?;
 
-    std::io::stdout().write(b"}")?;
+    std::io::stdout().write_all(b"}")?;
 
     return Ok(());
 }
@@ -305,14 +305,14 @@ fn main() {
 
     let mut initial = true;
     if cli.array {
-        std::io::stdout().write(b"[").unwrap();
+        std::io::stdout().write_all(b"[").unwrap();
     }
     loop {
         if initial {
             initial = false;
         } else {
             if cli.array {
-                std::io::stdout().write(b",").unwrap();
+                std::io::stdout().write_all(b",").unwrap();
             }
         }
         if let Err(err) = process_response(&cli, &mut lbin) {
@@ -320,13 +320,13 @@ fn main() {
             break;
         }
         if !cli.array {
-            std::io::stdout().write(b"\n").unwrap();
+            std::io::stdout().write_all(b"\n").unwrap();
         }
         if lbin.is_eof() {
             break;
         }
     }
     if cli.array {
-        std::io::stdout().write(b"]\n").unwrap();
+        std::io::stdout().write_all(b"]\n").unwrap();
     }
 }


### PR DESCRIPTION
### Reference

- https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all
- https://rust-lang.github.io/rust-clippy/master/index.html#unused_io_amount

(Sorry if you have already known `cargo clippy`) `cargo clippy` detects such warnings/error as below. I recommend that you use it. You can also run `cargo clippy` on save on Visual Studio Code with [some configurations](https://users.rust-lang.org/t/how-to-use-clippy-in-vs-code-with-rust-analyzer/41881/2). (However it makes VScode a bit slow )

```
warning: unneeded `return` statement
   --> src/main.rs:295:5
    |
295 |     return Ok(());
    |     ^^^^^^^^^^^^^^ help: remove `return`: `Ok(())`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

error: written amount is not handled. Use `Write::write_all` instead
   --> src/main.rs:273:5
    |
273 |     std::io::stdout().write(b"{")?;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[deny(clippy::unused_io_amount)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unused_io_amount
```